### PR TITLE
Force a compile before packaging up WAR files

### DIFF
--- a/src/leiningen/uberwar.clj
+++ b/src/leiningen/uberwar.clj
@@ -1,5 +1,6 @@
 (ns leiningen.uberwar
   "Leiningen uberwar plugin"
+  (:require [leiningen.compile :as compile])
   (:use leiningen.war)
   (:use leiningen.web-xml))
 
@@ -39,6 +40,7 @@
   Artifacts listed in :dev-dependencies will not copied into the war file"
   [project & args]
   (autocreate-webxml project)
+  (compile/compile project)
   (check-exists (:library-path project))
   (jar (war-name project)
        ["WEB-INF/web.xml" (webxml-path project)]

--- a/src/leiningen/war.clj
+++ b/src/leiningen/war.clj
@@ -4,6 +4,7 @@
         [clojure.contrib.str-utils :only [str-join re-sub re-gsub]]
         [clojure.contrib.java-utils :only [file]])
   (:use leiningen.web-xml)
+  (:require [leiningen.compile :as compile])
   (:import [java.util.jar Manifest JarEntry JarOutputStream]
            [java.io BufferedOutputStream 
                     FileOutputStream 
@@ -142,6 +143,7 @@ file object."
    WEB-INF/classes             src                    :source-path"
   [project & args]
   (autocreate-webxml project)
+  (compile/compile project)
   (jar (war-name project)
        ["WEB-INF/web.xml" (webxml-path project)]
        ["WEB-INF/classes/" (:compile-path project)]


### PR DESCRIPTION
Hi there,

Not sure if this is something you'd want in the main branch, but something that's bitten me several times with the war/uberwar tasks is that it does not automatically compile my :gen-classes. This means that any servlets referenced in web.xml may not be available when deployed to a container.

I'm thinking it might be useful to add a check for a project option to determine whether to force a compile, but figure this is a reasonable (and simple!) enough first cut.

Cheers,
Tom
