### PR TITLE
Fixes Issue #6

### DIFF
--- a/src/leiningen/war.clj
+++ b/src/leiningen/war.clj
@@ -17,7 +17,7 @@
 (defn unix-path [path] (re-gsub #"\\" "/" path))
 (defn has-trailing-slash [path] (re-find #"/$" path))
 (defn scratch-file? [path] (re-find #"[~#]$" path))
-(defn hidden? [path] (re-find #"/\." path))
+(defn hidden? [path] (re-find #"^\." (last (re-split #"/" path))))
 
 (defn find-files 
   "Returns all files in and below the given directory. If 


### PR DESCRIPTION
As mentioned in the issue comments, if the folder structure of the application has a "." in a folder name it errors on uberwar.  This fix changes `hidden?` to only test the filename and not the full path string.
